### PR TITLE
fix(site): remove unnecessary encoding declaration and improve error …

### DIFF
--- a/app/site/compose/__init__.py
+++ b/app/site/compose/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 HTML Export extensions of LOD database models
 """

--- a/app/site/functions.py
+++ b/app/site/functions.py
@@ -31,7 +31,7 @@ def get_data(url: str) -> str | BeautifulSoup:
     log.debug(m_l["url_check"])
 
     if not re.match(pattern_http, url):
-        return ""
+        raise ValueError()
 
     log.debug(m_l["url_correct"], url)
     log.debug(m_l["get_site"])
@@ -45,4 +45,4 @@ def get_data(url: str) -> str | BeautifulSoup:
 
     except HTTPError as err:
         log.error(m_l["error"], url, err)
-        return str(err)
+        raise err


### PR DESCRIPTION
…handling

- Remove redundant UTF-8 encoding declaration from __init__.py
- Replace empty string return with proper ValueError exception in URL validation
- Re-raise HTTPError instead of returning error string for better error propagation